### PR TITLE
Add electron rebuild script and update build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ Download the PoeAggregator.Setup.<version number>exe
 Once installed, click the "Settings" button.
 
 poesessionid must be set in order to run live searches.
+
+## Building from source
+
+To create a distributable build, run the following commands in the `app` directory:
+
+```
+npm install
+npm run rebuild
+npm run dist
+```
+
+Running `npm run rebuild` (powered by [`@electron/rebuild`](https://github.com/electron/rebuild)) ensures native modules are rebuilt before packaging with `npm run dist`.

--- a/app/package.json
+++ b/app/package.json
@@ -6,13 +6,15 @@
   "scripts": {
     "start": "electron .",
     "pack": "electron-builder --dir",
-    "dist": "electron-builder"
+    "dist": "electron-builder",
+    "rebuild": "npx @electron/rebuild"
   },
   "author": "cpieprzak",
   "license": "ISC",
   "devDependencies": {
     "electron": "^13.1.6",
-    "electron-builder": "22.10.5"
+    "electron-builder": "22.10.5",
+    "@electron/rebuild": "^4.0.1"
   },
   "build": {
     "appId": "poe-aggregator"


### PR DESCRIPTION
## Summary
- add `rebuild` script using `npx @electron/rebuild`
- document running `npm run rebuild` before packaging

## Testing
- `cd app && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689e5a76f1448329ad4588c50833c88c